### PR TITLE
Guard against panic over extern "C"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -Dwarnings
+  CI: 1
 
 jobs:
   test:
@@ -33,14 +34,13 @@ jobs:
       # isn't reason to believe this would be very rust-version dependent.
       - run: cargo build --manifest-path=testcases/dylib/Cargo.toml
         if: matrix.rust != '1.37.0'
-      # hack to figure out why windows is busted
-      - run: ls testcases/target
-        shell: bash
-      - run: ls testcases/target/debug
-        shell: bash
-        # if: matrix.os == 'windows-latest'
-      - run: cargo run --manifest-path=testcases/dylib_runner/Cargo.toml -- testcases/target/debug
+      - run: cargo run --manifest-path=testcases/dylib_runner/Cargo.toml -- testcases/target/debug dylibtest
         if: matrix.rust != '1.37.0'
+      - run: cargo build --manifest-path=testcases/paniclib/Cargo.toml
+        if: matrix.rust != '1.37.0'
+      - run: bash scripts/test_panic_afterbuild.sh
+        env: { RUST_BACKTRACE: 0 }
+        if: matrix.rust != '1.37.0' && matrix.os != 'windows-latest'
 
   checks:
     name: Lint and rustfmt

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# run like `bash scripts/test.sh`. not used in CI, but mimics it.
+
+set -euvx
+
+cargo run --manifest-path=testcases/smokebin/Cargo.toml --all-features
+cargo build --manifest-path=testcases/dylib/Cargo.toml
+cargo run --manifest-path=testcases/dylib_runner/Cargo.toml -- testcases/target/debug dylibtest
+cargo build --manifest-path=testcases/paniclib/Cargo.toml
+
+bash scripts/test_panic_afterbuild.sh

--- a/scripts/test_panic_afterbuild.sh
+++ b/scripts/test_panic_afterbuild.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# don't call me directly, call from test.sh or in CI
+if test "$CI" = "1"; then
+    set -v
+fi
+
+# run in subshell to avoid getting killed by the signal
+# note: `trap` doesn't help here.
+# shellcheck disable=SC2091
+$(./testcases/target/debug/dylib_runner testcases/target/debug paniclib)
+status="$?"
+echo "note: paniclib exited with $status (should be an error)"
+if test "$status" -eq "0"; then
+    echo "paniclib should not successfully exit" >&2
+    exit 1
+fi
+
+if test "$status" -eq "99"; then
+    echo "paniclib should abort, not catch the panic" >&2
+    exit 1
+fi
+
+echo "panic test passed!"

--- a/testcases/Cargo.toml
+++ b/testcases/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["dylib", "dylib_runner", "smokebin"]
+members = ["dylib", "dylib_runner", "smokebin", "paniclib"]

--- a/testcases/dylib_runner/main.rs
+++ b/testcases/dylib_runner/main.rs
@@ -1,12 +1,7 @@
 fn main() {
     let mut args = std::env::args().skip(1);
-    let path: std::path::PathBuf = args
-        .next()
-        .expect("expected target path")
-        .into();
-    let name = args
-        .next()
-        .expect("expected lib name");
+    let path: std::path::PathBuf = args.next().expect("expected target path").into();
+    let name = args.next().expect("expected lib name");
 
     let sofile = path.join(format!("lib{}.so", name));
     let dll = path.join(format!("{}.dll", name));
@@ -18,7 +13,10 @@ fn main() {
     } else if dylib.exists() {
         dylib
     } else {
-        panic!("couldnt find a dylib like {:?}, {:?}, or {:?}", sofile, dll, dylib);
+        panic!(
+            "couldnt find a dylib like {:?}, {:?}, or {:?}",
+            sofile, dll, dylib
+        );
     };
     let r = maybe_catch_unwind(name == "paniclib", || {
         let lib = libloading::Library::new(&file).unwrap_or_else(|e| {

--- a/testcases/dylib_runner/main.rs
+++ b/testcases/dylib_runner/main.rs
@@ -8,7 +8,7 @@ fn main() {
         .next()
         .expect("expected lib name");
 
-    let sofile = path.join(format!("lib{}.som", name));
+    let sofile = path.join(format!("lib{}.so", name));
     let dll = path.join(format!("{}.dll", name));
     let dylib = path.join(format!("lib{}.dylib", name));
     let file: std::path::PathBuf = if sofile.exists() {
@@ -18,7 +18,7 @@ fn main() {
     } else if dylib.exists() {
         dylib
     } else {
-        panic!("couldnt find a dylib like {:?}", path);
+        panic!("couldnt find a dylib like {:?}, {:?}, or {:?}", sofile, dll, dylib);
     };
     let r = maybe_catch_unwind(name == "paniclib", || {
         let lib = libloading::Library::new(&file).unwrap_or_else(|e| {

--- a/testcases/paniclib/Cargo.toml
+++ b/testcases/paniclib/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "paniclib"
+version = "0.1.0"
+authors = ["Thom Chiovoloni <chiovolonit@gmail.com>"]
+edition = "2018"
+publish = false
+
+[lib]
+name = "paniclib"
+crate_type = ["cdylib"]
+path = "lib.rs"
+
+[dependencies]
+startup = { path = "../.." }

--- a/testcases/paniclib/lib.rs
+++ b/testcases/paniclib/lib.rs
@@ -1,0 +1,7 @@
+// Shouldn't panic over unwind boundary.
+startup::on_startup! { panic!(); }
+
+#[no_mangle]
+pub extern "C" fn startup_testcase() -> bool {
+    true
+}

--- a/testcases/test.sh
+++ b/testcases/test.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-# run like `bash testcases/smokebin.sh`. not used in CI, but mimics it.
-
-set -euvx
-
-cargo run --manifest-path=testcases/smokebin/Cargo.toml
-cargo build --manifest-path=testcases/dylib/Cargo.toml
-cargo run --manifest-path testcases/dylib_runner/Cargo.toml -- testcases/target/debug


### PR DESCRIPTION
This isn't needed in practice since libstd aborts if you do it (even when loaded dynamically) but in the future, theoretically stdlib could gain support for unwinding before main. If that happens, this patch is needed to prevent UB.

The hard thing here was testing this code. We assume that if libstd is ever gonna support unwinding before main, it's going to be in the dynamic loading case, (since there's an initialized runtime), and so that's what we test.